### PR TITLE
Agregar valor por defecto a variables tipo numero.

### DIFF
--- a/tabla_simbolos.js
+++ b/tabla_simbolos.js
@@ -10,7 +10,7 @@ const TIPO_DATO = {
  * @param {*} tipo 
  * @param {*} valor 
  */
-function crearSimbolo(id, tipo, valor) {
+function crearSimbolo(id, tipo, valor=0) {
     return {
         id: id,
         tipo: tipo,


### PR DESCRIPTION
Al asignar un valor por defecto al parametro 'valor' de la funcion 'crearSimbolo', se podria definir un valor por defecto a las variables de tipo numero en el interprete.
Esta modificacion solamente es valida al ser numero el unico tipo de variables que son aceptadas por el interprete. Si se agregan mas tipos de variables se deberia proceder de otra manera.